### PR TITLE
Suspend and Wakup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ embassy-embedded-hal = { version = "0.5.0", features = ["defmt"] }
 embassy-sync = { version = "0.7.2", features = ["defmt"] }
 embassy-executor = { version = "0.9.0", features = ["arch-cortex-m", "executor-thread", "executor-interrupt", "defmt"] }
 embassy-time = { version = "0.5.0", features = ["defmt", "defmt-timestamp-uptime"] }
-embassy-rp = { version = "0.8.0", features = ["defmt", "unstable-pac", "time-driver", "critical-section-impl", "rp2040", "boot2-w25q080" ] }
+embassy-rp = { version = "0.9.0", features = ["defmt", "unstable-pac", "time-driver", "critical-section-impl", "rp2040", "boot2-w25q080" ] }
 embassy-usb = { version = "0.5.1", features = ["defmt"] }
 embassy-futures = { version = "0.1.2" }
 
@@ -22,7 +22,7 @@ cortex-m-rt = "0.7.0"
 critical-section = "1.1"
 panic-probe = { version = "1.0.0", features = ["print-defmt"] }
 smart-leds = "0.4.0"
-usbd-hid = "0.8.2"
+usbd-hid = "0.9.0"
 heapless = "0.9.2"
 
 embedded-hal-1 = { package = "embedded-hal", version = "1.0" }
@@ -30,9 +30,13 @@ static_cell = "2.1"
 portable-atomic = { version = "1.5", features = ["critical-section"] }
 
 # patching because there seems to be a bug in the released versions of the executor and sync
-#[patch.crates-io]
-#embassy-sync = { git = "https://github.com/embassy-rs/embassy", rev = "94f9b2707486ca3eade5bf4b237edf3d6aa90f35" }
-#embassy-executor = { git = "https://github.com/embassy-rs/embassy", rev = "94f9b2707486ca3eade5bf4b237edf3d6aa90f35" }
+[patch.crates-io]
+embassy-sync = { git = "https://github.com/embassy-rs/embassy", rev = "fcd5383f475f7bd413541123d941d3d7e1cd326b" }
+embassy-executor = { git = "https://github.com/embassy-rs/embassy", rev = "fcd5383f475f7bd413541123d941d3d7e1cd326b" }
+embassy-rp = { git = "https://github.com/embassy-rs/embassy", rev = "fcd5383f475f7bd413541123d941d3d7e1cd326b" }
+embassy-usb = { git = "https://github.com/embassy-rs/embassy", rev = "fcd5383f475f7bd413541123d941d3d7e1cd326b" }
+embassy-time = { git = "https://github.com/embassy-rs/embassy", rev = "fcd5383f475f7bd413541123d941d3d7e1cd326b" }
+embassy-futures = { git = "https://github.com/embassy-rs/embassy", rev = "fcd5383f475f7bd413541123d941d3d7e1cd326b" }
 
 [profile.release]
 debug = 2

--- a/src/cc_engine/key_state.rs
+++ b/src/cc_engine/key_state.rs
@@ -170,6 +170,7 @@ impl KeySM {
             Key::Media(_) => Some(self.active_key),
             Key::Sys(_) => Some(self.active_key),
             Key::Shft(_) => Some(self.active_key),
+            Key::Ctrl(_) => Some(self.active_key),
         }
     }
 }

--- a/src/cc_engine/keycodes.rs
+++ b/src/cc_engine/keycodes.rs
@@ -68,6 +68,11 @@ pub enum Hid {
     Tab = 0x2B,
 
     Space = 0x2C,
+    Dash = 0x2D,
+    Eq = 0x2E,
+    LBrace = 0x2F,
+    RBrace = 0x30,
+    BSlsh = 0x31,
 
     Semicln = 0x33,
     Quote = 0x34,

--- a/src/cc_engine/keycodes.rs
+++ b/src/cc_engine/keycodes.rs
@@ -9,7 +9,8 @@ pub enum Key {
     Mod(Mod),     // modifier keycodes
     Media(Media), // media keys
     Sys(Sys),     // system commands
-    Shft(Hid),
+    Shft(Hid),    // SHIFT + keycode
+    Ctrl(Hid),    // CTRL + Keycode
     //Snap
 
     // custom codes begin
@@ -71,6 +72,7 @@ pub enum Hid {
     Semicln = 0x33,
     Quote = 0x34,
 
+    AccTil = 0x35,
     Com = 0x36,
     Dot = 0x37,
     Slash = 0x38,

--- a/src/cc_engine/macros/mod.rs
+++ b/src/cc_engine/macros/mod.rs
@@ -1,5 +1,8 @@
 #[allow(dead_code)]
-use crate::cc_engine::{keycodes, tasks::resources};
+use crate::cc_engine::{
+    keycodes,
+    tasks::resources::{self, GenericHidReport},
+};
 use usbd_hid::descriptor::KeyboardReport;
 
 use super::keycodes::Hid;
@@ -10,23 +13,23 @@ pub fn send_string(str: &str) {
     for character in str.chars() {
         if character.is_uppercase() {
             report.modifier |= keycodes::Mod::Lshft as u8;
-            let _ = resources::KEYBOARD_REPORT_CHANNEL.try_send(report);
+            let _ = resources::REPORT_CHANNEL.try_send(GenericHidReport::Keyboard(report));
         } else {
             report.modifier = 0;
-            let _ = resources::KEYBOARD_REPORT_CHANNEL.try_send(report);
+            let _ = resources::REPORT_CHANNEL.try_send(GenericHidReport::Keyboard(report));
         }
 
         // ignoring send error for now
         report.keycodes[0] = keycodes::Hid::from(character) as u8;
-        let _ = resources::KEYBOARD_REPORT_CHANNEL.try_send(report);
+        let _ = resources::REPORT_CHANNEL.try_send(GenericHidReport::Keyboard(report));
 
         // hacky to allow sending multiples of a single chracter
         report.keycodes[0] = 0;
-        let _ = resources::KEYBOARD_REPORT_CHANNEL.try_send(report);
+        let _ = resources::REPORT_CHANNEL.try_send(GenericHidReport::Keyboard(report));
     }
 
     report = KeyboardReport::default();
-    let _ = resources::KEYBOARD_REPORT_CHANNEL.try_send(report);
+    let _ = resources::REPORT_CHANNEL.try_send(GenericHidReport::Keyboard(report));
 }
 
 // description: sends a single keycode
@@ -34,9 +37,9 @@ pub fn send_string(str: &str) {
 pub fn send_keycode(code: &Hid) {
     let mut report = KeyboardReport::default();
     report.keycodes[0] = (*code) as u8;
-    let _ = resources::KEYBOARD_REPORT_CHANNEL.try_send(report);
+    let _ = resources::REPORT_CHANNEL.try_send(GenericHidReport::Keyboard(report));
 
     // cancel it
     report.keycodes[0] = 0;
-    let _ = resources::KEYBOARD_REPORT_CHANNEL.try_send(report);
+    let _ = resources::REPORT_CHANNEL.try_send(GenericHidReport::Keyboard(report));
 }

--- a/src/cc_engine/matrix.rs
+++ b/src/cc_engine/matrix.rs
@@ -78,7 +78,6 @@ impl<'a, const ROW_SIZE: usize, const COL_SIZE: usize> KeyboardMatrix<'a, ROW_SI
                 // poll by settign columns and readings rows
                 for (col_index, col) in &mut self.columns.iter_mut().enumerate() {
                     col.set_high();
-                    cortex_m::asm::delay(110); // need this because of my poorly chosen diode direction
 
                     // poll the rows
                     for (row_index, row) in &mut self.rows.iter_mut().enumerate() {
@@ -86,13 +85,17 @@ impl<'a, const ROW_SIZE: usize, const COL_SIZE: usize> KeyboardMatrix<'a, ROW_SI
                         self.keys[adjusted_index].process(&row.is_high(), &mut self.active_layer);
                     }
                     col.set_low();
+
+                    // wait for all rows to go low before moving to next column ( TODO! Just check a bit mask here of the gpio register so we don't have to loop)
+                    for row in &mut self.rows.iter_mut() {
+                        while row.is_high() {} // loop
+                    }
                 }
             }
             DiodeDirection::RowToColumn => {
                 // poll by setting rows and reading columns
                 for (row_index, row) in &mut self.rows.iter_mut().enumerate() {
                     row.set_high();
-                    cortex_m::asm::delay(110); // need this because of my poorly chosen diode direction
 
                     // poll the columns
                     for (col_index, col) in &mut self.columns.iter_mut().enumerate() {
@@ -100,6 +103,11 @@ impl<'a, const ROW_SIZE: usize, const COL_SIZE: usize> KeyboardMatrix<'a, ROW_SI
                         self.keys[adjusted_index].process(&col.is_high(), &mut self.active_layer);
                     }
                     row.set_low();
+
+                    // wait for all rows to go low before moving to next column ( TODO! Just check a bit mask here of the gpio register so we don't have to loop)
+                    for column in &mut self.columns.iter_mut() {
+                        while column.is_high() {} // loop
+                    }
                 }
             }
         };

--- a/src/cc_engine/processing.rs
+++ b/src/cc_engine/processing.rs
@@ -27,6 +27,14 @@ pub fn process_keyboard_report(result: &[KeySM]) -> descriptor::KeyboardReport {
                             index += 1;
                         }
                     }
+                    Key::Ctrl(keycode) => {
+                        if index < 6 {
+                            // auto apply shift for this keycode
+                            report.keycodes[index] = keycode as u8;
+                            report.modifier |= Mod::Lctrl as u8;
+                            index += 1;
+                        }
+                    }
                     _ => (), // ignore all other keycodes
                 }
             }

--- a/src/cc_engine/tasks/polling.rs
+++ b/src/cc_engine/tasks/polling.rs
@@ -1,5 +1,9 @@
-use crate::cc_engine::{self, matrix};
+use crate::cc_engine::{
+    self, matrix,
+    tasks::resources::{SUSPENDED, WAKE_SIGNAL},
+};
 use embassy_time::Timer;
+use usbd_hid::descriptor::KeyboardReport;
 
 // crate includes
 use super::resources;
@@ -19,7 +23,18 @@ pub async fn matrix_polling_handler(
         let result = key_matrix.poll();
         let report = cc_engine::processing::process_keyboard_report(result);
 
-        resources::KEYBOARD_REPORT_CHANNEL.send(report).await;
+        if !SUSPENDED.load(core::sync::atomic::Ordering::Acquire) {
+            resources::REPORT_CHANNEL
+                .send(resources::GenericHidReport::Keyboard(report))
+                .await;
+        } else {
+            // if not awake, send a wake signal if any key is pressed
+            if report != KeyboardReport::default() {
+                WAKE_SIGNAL.signal(());
+                SUSPENDED.store(false, core::sync::atomic::Ordering::Release);
+            }
+        }
+
         Timer::after_millis(1).await;
     }
 }

--- a/src/cc_engine/tasks/resources.rs
+++ b/src/cc_engine/tasks/resources.rs
@@ -1,26 +1,30 @@
 // resources.rs
 // description: contains shared resources for use between tasks
 
+use core::sync::atomic::AtomicBool;
+
 // embassy includes
 use embassy_sync::channel::Channel;
 use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, signal::Signal};
 use smart_leds::RGB8;
 use usbd_hid::descriptor::{KeyboardReport, MediaKeyboardReport, MouseReport, SystemControlReport};
 
+#[allow(dead_code)]
+pub enum GenericHidReport {
+    Keyboard(KeyboardReport),
+    Media(MediaKeyboardReport),
+    Mouse(MouseReport),
+    System(SystemControlReport),
+}
+
 // ridiculous buffer sizes but I've got memory so why not
-pub static KEYBOARD_REPORT_CHANNEL: Channel<CriticalSectionRawMutex, KeyboardReport, 100> =
-    Channel::new();
-pub static MEDIA_REPORT_CHANNEL: Channel<CriticalSectionRawMutex, MediaKeyboardReport, 100> =
-    Channel::new();
-pub static MOUSE_REPORT_CHANNEL: Channel<CriticalSectionRawMutex, MouseReport, 100> =
-    Channel::new();
-pub static SYSTEM_CONTROL_REPORT_CHANNEL: Channel<
-    CriticalSectionRawMutex,
-    SystemControlReport,
-    100,
-> = Channel::new();
+pub static REPORT_CHANNEL: Channel<CriticalSectionRawMutex, GenericHidReport, 100> = Channel::new();
 
 pub static STATUS_SIGNAL: Signal<CriticalSectionRawMutex, Status> = Signal::new();
+
+pub static WAKE_SIGNAL: Signal<CriticalSectionRawMutex, ()> = Signal::new();
+
+pub static SUSPENDED: AtomicBool = AtomicBool::new(false);
 
 #[allow(dead_code)]
 pub enum Status {

--- a/src/cc_engine/tasks/status.rs
+++ b/src/cc_engine/tasks/status.rs
@@ -3,7 +3,7 @@ use embassy_rp::{
     bind_interrupts,
     peripherals::{self, DMA_CH0, PIO0},
     pio::{InterruptHandler, Pio},
-    pio_programs::ws2812::{PioWs2812, PioWs2812Program},
+    pio_programs::ws2812::{Grb, PioWs2812, PioWs2812Program},
     Peri,
 };
 use embassy_time::Timer;
@@ -28,7 +28,7 @@ pub async fn status_light_handler(
 
     const NUM_LEDS: usize = 1;
     let program = PioWs2812Program::new(&mut common);
-    let mut led_output: PioWs2812<'_, PIO0, 0, NUM_LEDS> =
+    let mut led_output: PioWs2812<'_, PIO0, 0, NUM_LEDS, Grb> =
         PioWs2812::new(&mut common, sm0, dma, status_led, &program);
 
     // initialize state

--- a/src/cc_engine/tasks/usb.rs
+++ b/src/cc_engine/tasks/usb.rs
@@ -184,7 +184,7 @@ impl hid::RequestHandler for MyRequestHandler {
         hid::HidProtocolMode::Report
     }
 
-    fn set_protocol(&mut self, protocol: hid::HidProtocolMode) -> control::OutResponse {
+    fn set_protocol(&mut self, _protocol: hid::HidProtocolMode) -> control::OutResponse {
         // TODO! Implement this
         control::OutResponse::Accepted
     }

--- a/src/cc_engine/tasks/usb.rs
+++ b/src/cc_engine/tasks/usb.rs
@@ -2,12 +2,17 @@
 use core::sync::atomic::{AtomicBool, Ordering};
 use defmt::*;
 use embassy_executor::Spawner;
-use embassy_futures::select::Either4;
+use embassy_futures::select::{select, Either};
+use embassy_rp::peripherals::WATCHDOG;
+use embassy_rp::watchdog::Watchdog;
 use embassy_rp::{peripherals, usb, Peri};
+use embassy_time::Instant;
 use embassy_usb::class::hid;
 use embassy_usb::control;
 use static_cell::StaticCell;
 use usbd_hid::descriptor::{AsInputReport, KeyboardReport, SerializedDescriptor};
+
+use crate::cc_engine::tasks::resources::{GenericHidReport, STATUS_SIGNAL, SUSPENDED, WAKE_SIGNAL};
 
 // local includes
 use super::resources;
@@ -19,6 +24,7 @@ embassy_rp::bind_interrupts!(struct Irqs {
 // task for setting up the usb handler and processing usb events
 pub fn initialize_usb_resources(
     usb_peripheral: Peri<'static, peripherals::USB>,
+    watchdog: Peri<'static, WATCHDOG>,
     spawner: &Spawner,
 ) {
     // Create the driver, from the HAL.
@@ -26,11 +32,12 @@ pub fn initialize_usb_resources(
 
     // Create embassy-usb Config
     let mut config = embassy_usb::Config::new(0xc0de, 0xcafe);
-    config.manufacturer = Some("Caserto LLE");
+    config.manufacturer = Some("CC LLE");
     config.product = Some("CC Keyboard");
     config.serial_number = Some("00000001");
     config.max_power = 100;
     config.max_packet_size_0 = 64;
+    config.supports_remote_wakeup = true;
 
     // Create embassy-usb DeviceBuilder using the driver and config.
     // It needs some buffers for building the descriptors.
@@ -57,6 +64,8 @@ pub fn initialize_usb_resources(
         request_handler: None,
         poll_ms: 1,
         max_packet_size: 64,
+        hid_subclass: hid::HidSubclass::No,
+        hid_boot_protocol: hid::HidBootProtocol::Keyboard,
     };
 
     static STATE: StaticCell<hid::State> = StaticCell::new();
@@ -69,13 +78,13 @@ pub fn initialize_usb_resources(
     let (reader, writer) = hid.split();
 
     // start the writer task
-    spawner.must_spawn(usb_out_handler(writer));
+    spawner.spawn(usb_out_handler(writer).unwrap());
 
     // start the reader task
-    spawner.must_spawn(usb_in_handler(reader));
+    spawner.spawn(usb_in_handler(reader).unwrap());
 
     // start the usb handler
-    spawner.must_spawn(usb_handler(usb));
+    spawner.spawn(usb_handler(usb, watchdog).unwrap());
 }
 
 #[embassy_executor::task]
@@ -85,25 +94,19 @@ async fn usb_out_handler(
     loop {
         // wait for a new keyboard report
         info!("Waiting keyboard report");
-        let report = embassy_futures::select::select4(
-            resources::KEYBOARD_REPORT_CHANNEL.receive(),
-            resources::MOUSE_REPORT_CHANNEL.receive(),
-            resources::MEDIA_REPORT_CHANNEL.receive(),
-            resources::SYSTEM_CONTROL_REPORT_CHANNEL.receive(),
-        )
-        .await;
+        let report = resources::REPORT_CHANNEL.receive().await;
 
         match &report {
-            Either4::First(keyboard_report) => {
+            GenericHidReport::Keyboard(keyboard_report) => {
                 write_report(keyboard_report, &mut writer).await;
             }
-            Either4::Second(mouse_report) => {
+            GenericHidReport::Mouse(mouse_report) => {
                 write_report(mouse_report, &mut writer).await;
             }
-            Either4::Third(media_report) => {
+            GenericHidReport::Media(media_report) => {
                 write_report(media_report, &mut writer).await;
             }
-            Either4::Fourth(system_control_report) => {
+            GenericHidReport::System(system_control_report) => {
                 write_report(system_control_report, &mut writer).await;
             }
         }
@@ -115,10 +118,12 @@ async fn write_report<T: AsInputReport>(
     report: &T,
     writer: &mut hid::HidWriter<'static, usb::Driver<'static, peripherals::USB>, 8>,
 ) {
-    match writer.write_serialize(report).await {
-        Ok(()) => {}
-        Err(e) => warn!("Failed to send report: {:?}", e),
-    };
+    if !SUSPENDED.load(Ordering::Acquire) {
+        match writer.write_serialize(report).await {
+            Ok(()) => {}
+            Err(e) => warn!("Failed to send report: {:?}", e),
+        };
+    }
 }
 
 #[embassy_executor::task]
@@ -135,9 +140,30 @@ async fn usb_in_handler(
 #[embassy_executor::task]
 async fn usb_handler(
     mut usb: embassy_usb::UsbDevice<'static, usb::Driver<'static, peripherals::USB>>,
+    watchdog: Peri<'static, WATCHDOG>,
 ) {
+    let mut watchdog_timer = Watchdog::new(watchdog);
+
     // run the usb device
-    usb.run().await;
+    loop {
+        usb.run_until_suspend().await;
+
+        // // now suspended, wait for wakeup
+        match select(usb.wait_resume(), WAKE_SIGNAL.wait()).await {
+            Either::First(_) => (),
+            Either::Second(_) => {
+                // set remote wakeup bit in usb registers ( embassy HAL doesn't support this for some reason? )
+                embassy_rp::pac::USB
+                    .sie_ctrl()
+                    .write(|w| w.set_resume(true));
+                // embassy_rp::pac::USB.inte().write(|r| r.set_dev_sof(true));
+
+                let start = Instant::now();
+                while Instant::now().duration_since(start).as_secs() <= 1 {}
+                watchdog_timer.trigger_reset(); // hacky as hell but easier than fixing broken usb state for now
+            }
+        }
+    }
 }
 
 struct MyRequestHandler {}
@@ -150,6 +176,16 @@ impl hid::RequestHandler for MyRequestHandler {
 
     fn set_report(&mut self, id: hid::ReportId, data: &[u8]) -> control::OutResponse {
         info!("Set report for {:?}: {=[u8]}", id, data);
+        control::OutResponse::Accepted
+    }
+
+    fn get_protocol(&self) -> hid::HidProtocolMode {
+        // TODO! Implement this
+        hid::HidProtocolMode::Report
+    }
+
+    fn set_protocol(&mut self, protocol: hid::HidProtocolMode) -> control::OutResponse {
+        // TODO! Implement this
         control::OutResponse::Accepted
     }
 
@@ -178,9 +214,11 @@ impl MyDeviceHandler {
 impl embassy_usb::Handler for MyDeviceHandler {
     fn enabled(&mut self, enabled: bool) {
         self.configured.store(false, Ordering::Relaxed);
+        SUSPENDED.store(false, Ordering::Release);
         if enabled {
             info!("Device enabled");
         } else {
+            STATUS_SIGNAL.signal(resources::Status::Error);
             info!("Device disabled");
         }
     }
@@ -203,6 +241,15 @@ impl embassy_usb::Handler for MyDeviceHandler {
             )
         } else {
             info!("Device is no longer configured, the Vbus current limit is 100mA.");
+            STATUS_SIGNAL.signal(resources::Status::Error);
+        }
+    }
+
+    fn suspended(&mut self, suspended: bool) {
+        if suspended {
+            SUSPENDED.store(true, Ordering::Release);
+        } else {
+            SUSPENDED.store(false, Ordering::Release);
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -20,30 +20,32 @@ type Keymap = [KbLayer; NUM_LAYERS as usize];
 #[rustfmt::skip]
 pub const KEYMAP: Keymap = [
 [
-    Hid(Tab),    Hid(Q),     Hid(W),    Hid(E),    Hid(R),       Hid(T),     Hid(Y),     Hid(U),       Hid(I),    Hid(O),    Hid(P),       Hid(Backsp),
-    Hid(Backsp), Hid(A),     Hid(S),    Hid(D),    Hid(F),       Hid(G),     Hid(H),     Hid(J),       Hid(K),    Hid(L),    Hid(Semicln), Hid(Quote),
-    Mod(Lshft),  Hid(Z),     Hid(X),    Hid(C),    Hid(V),       Hid(B),     Hid(N),     Hid(M),       Hid(Com),  Hid(Dot),  Hid(Slash),   Hid(Enter),
-    Hid(Esc),    Mod(Lctrl), Mod(Lalt), Mod(Lgui), Layer(1),     Hid(Space), Hid(Space), Layer(2),     Hid(Left), Hid(Down), Hid(Up),      Hid(Right),
+    Hid(Tab),   Hid(Q),     Hid(W),    Hid(E),    Hid(R),   Hid(T),     Hid(Y),     Hid(U),   Hid(I),    Hid(O),    Hid(P),       Hid(Backsp),
+    Hid(Esc),   Hid(A),     Hid(S),    Hid(D),    Hid(F),   Hid(G),     Hid(H),     Hid(J),   Hid(K),    Hid(L),    Hid(Semicln), Hid(Quote),
+    Mod(Lshft), Hid(Z),     Hid(X),    Hid(C),    Hid(V),   Hid(B),     Hid(N),     Hid(M),   Hid(Com),  Hid(Dot),  Hid(Slash),   Hid(Enter),
+    Pass,       Mod(Lctrl), Mod(Lalt), Mod(Lgui), Layer(1), Hid(Space), Hid(Space), Layer(2), Hid(Left), Hid(Down), Hid(Up),      Hid(Right),
 ],
 [
-    Shft(AccTil), Hid(N1),  Hid(N2),  Hid(N3),  Hid(N4),  Hid(N5),  Hid(N6),   Hid(N7),   Hid(N8), Hid(N9),    Hid(N0), Pass,
-    Pass,         Pass,     Ctrl(S),  Hid(F03), Hid(F04), Hid(F05), Hid(Left), Hid(Down), Hid(Up), Hid(Right), Pass,    Pass,
-    Pass,         Hid(F07), Hid(F08), Hid(F09), Hid(F10), Hid(F11), Hid(F12),  Pass,      Pass,    Pass,       Pass,    Pass,
-    Macro(m1),    Pass,     Pass,     Pass,     Pass,     Pass,     Pass,      Pass,      Pass,    Pass,       Pass,    Pass,
+    Shft(AccTil), Shft(N1), Shft(N2), Shft(N3), Shft(N4), Shft(N5), Shft(N6), Shft(N7),   Shft(N8), Shft(N9),     Shft(N0),     Hid(Backsp),
+    Hid(Del),     Hid(F01), Ctrl(S),  Hid(F03), Hid(F04), Hid(F05), Hid(F06), Shft(Dash), Shft(Eq), Shft(LBrace), Shft(RBrace), Shft(BSlsh),
+    Pass,         Hid(F07), Hid(F08), Hid(F09), Hid(F10), Hid(F11), Hid(F12), Pass,       Pass,     Hid(Home),    Hid(End),     Pass,
+    Macro(m1),    Pass,     Pass,     Pass,     Pass,     Pass,     Pass,     Pass,       Pass,     Pass,         Pass,         Pass,
 ],
 [
-    Pass,      Hid(N0), Hid(N1), Hid(N2), Hid(N3), Pass, Pass, Pass,  Hid(F01), Hid(F02), Hid(F03), Hid(F04),
-    Pass,      Pass,    Hid(N4), Hid(N5), Hid(N6), Pass, Pass, Pass,  Hid(F05), Hid(F06), Hid(F07), Hid(F08),
-    Pass,      Pass,    Hid(N7), Hid(N8), Hid(N9), Pass, Pass, Pass,  Hid(F09), Hid(F10), Hid(F11), Hid(F12),
-    Macro(m2), Pass,    Pass,    Pass,    Pass,    Pass, Pass, Pass,  Pass, Pass, Pass, Pass,
+    Hid(AccTil), Hid(N1),  Hid(N2),  Hid(N3),  Hid(N4),  Hid(N5),  Hid(N6),  Hid(N7),   Hid(N8),  Hid(N9),     Hid(N0),     Hid(Backsp),
+    Pass,        Hid(F01), Hid(F02), Hid(F03), Hid(F04), Hid(F05), Hid(F06), Hid(Dash), Hid(Eq),  Hid(LBrace), Hid(RBrace), Hid(BSlsh),
+    Pass,        Hid(F07), Hid(F08), Hid(F09), Hid(F10), Hid(F11), Hid(F12), Pass,      Pass,     Hid(PgUp),   Hid(PgDn),   Pass,
+    Macro(m2),   Pass,     Pass,     Pass,     Pass,     Pass,     Pass,     Pass,      Pass,     Pass,        Pass,        Pass,
 ]
 ];
 
 fn m1() {
     // do stuff
     use super::cc_engine::macros;
-    macros::send_string("Test String");
-    // macros::send_mouse_input(50, 50);
+    let test_text = "Lorem ipsum dolor sit amet. Eum dignissimos optio a aperiam exercitationem eos totam deserunt. Sed nisi distinctio ut quia ducimus quo architecto corrupti ut nisi natus sed atque molestiae id molestias labore ut numquam quas.
+
+Eos eveniet quod ab veritatis dolor ut omnis ratione. Eos tempora accusamus quo aliquam galisum id dolorem sunt!";
+    macros::send_string(test_text);
 }
 
 fn m2() {

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,7 +2,7 @@
 // Description: Contains information about the keyboard keymap
 use crate::cc_engine::keycodes::Hid::*;
 #[allow(unused_imports)]
-use crate::cc_engine::keycodes::Key::{self, Hid, Layer, Macro, Mod, Pass, Shft, DT, MT};
+use crate::cc_engine::keycodes::Key::{self, Ctrl, Hid, Layer, Macro, Mod, Pass, Shft, DT, MT};
 use crate::cc_engine::keycodes::{self, Mod::*};
 
 pub const ROWS: u8 = 4;
@@ -26,15 +26,15 @@ pub const KEYMAP: Keymap = [
     Hid(Esc),    Mod(Lctrl), Mod(Lalt), Mod(Lgui), Layer(1),     Hid(Space), Hid(Space), Layer(2),     Hid(Left), Hid(Down), Hid(Up),      Hid(Right),
 ],
 [
-    Pass,      Pass,     Pass,     Pass,     Pass,     Pass,     Pass,      Pass,      Pass,    Pass,       Pass, Pass,
-    Pass,      Hid(F01), Hid(F02), Hid(F03), Hid(F04), Hid(F05), Hid(Left), Hid(Down), Hid(Up), Hid(Right), Pass, Pass,
-    Pass,      Hid(F07), Hid(F08), Hid(F09), Hid(F10), Hid(F11), Hid(F12),  Pass,      Pass,    Pass,       Pass, Pass,
-    Macro(m1), Pass,     Pass,     Pass,     Pass,     Pass,     Pass,      Pass,      Pass,    Pass,       Pass, Pass,
+    Shft(AccTil), Hid(N1),  Hid(N2),  Hid(N3),  Hid(N4),  Hid(N5),  Hid(N6),   Hid(N7),   Hid(N8), Hid(N9),    Hid(N0), Pass,
+    Pass,         Pass,     Ctrl(S),  Hid(F03), Hid(F04), Hid(F05), Hid(Left), Hid(Down), Hid(Up), Hid(Right), Pass,    Pass,
+    Pass,         Hid(F07), Hid(F08), Hid(F09), Hid(F10), Hid(F11), Hid(F12),  Pass,      Pass,    Pass,       Pass,    Pass,
+    Macro(m1),    Pass,     Pass,     Pass,     Pass,     Pass,     Pass,      Pass,      Pass,    Pass,       Pass,    Pass,
 ],
 [
-    Pass,      Hid(N0), Hid(N1), Hid(N2), Hid(N3), Pass, Pass, Pass,  Pass, Pass, Pass, Pass,
-    Pass,      Pass,    Hid(N4), Hid(N5), Hid(N6), Pass, Pass, Pass,  Pass, Pass, Pass, Pass,
-    Pass,      Pass,    Hid(N7), Hid(N8), Hid(N9), Pass, Pass, Pass,  Pass, Pass, Pass, Pass,
+    Pass,      Hid(N0), Hid(N1), Hid(N2), Hid(N3), Pass, Pass, Pass,  Hid(F01), Hid(F02), Hid(F03), Hid(F04),
+    Pass,      Pass,    Hid(N4), Hid(N5), Hid(N6), Pass, Pass, Pass,  Hid(F05), Hid(F06), Hid(F07), Hid(F08),
+    Pass,      Pass,    Hid(N7), Hid(N8), Hid(N9), Pass, Pass, Pass,  Hid(F09), Hid(F10), Hid(F11), Hid(F12),
     Macro(m2), Pass,    Pass,    Pass,    Pass,    Pass, Pass, Pass,  Pass, Pass, Pass, Pass,
 ]
 ];
@@ -43,6 +43,7 @@ fn m1() {
     // do stuff
     use super::cc_engine::macros;
     macros::send_string("Test String");
+    // macros::send_mouse_input(50, 50);
 }
 
 fn m2() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,14 +66,14 @@ fn main() -> ! {
         move || {
             let executor1 = EXECUTOR1.init(Executor::new());
             executor1
-                .run(|spawner| spawner.must_spawn(polling::matrix_polling_handler(key_matrix)));
+                .run(|spawner| spawner.spawn(polling::matrix_polling_handler(key_matrix).unwrap()));
         },
     );
 
     // start the core 0 tasks (just status led and usb handling for now)
     let executor0 = EXECUTOR0.init(Executor::new());
     executor0.run(|spawner| {
-        spawner.must_spawn(status::status_light_handler(p.PIN_17, p.PIO0, p.DMA_CH0));
-        usb::initialize_usb_resources(p.USB, &spawner);
+        spawner.spawn(status::status_light_handler(p.PIN_17, p.PIO0, p.DMA_CH0).unwrap());
+        usb::initialize_usb_resources(p.USB, p.WATCHDOG, &spawner);
     });
 }


### PR DESCRIPTION
Adding basic suspend and wakeup functionality. Implementation is hacky because embassy-rs does not support wakeup on the RP2040 and just setting the wakeup register alone currently breaks usb functionality. Currently I am resetting the MCU via the watchdog after sending the host remote wakeup command which works but isn't clean or something that could be upstreamed to the RP2040 embassy-rs drivers. I'd like to actually address this issue and upstream it to embassy-rs at some point.